### PR TITLE
Building correct pom.xml

### DIFF
--- a/jcenter/maven-install.gradle
+++ b/jcenter/maven-install.gradle
@@ -34,6 +34,13 @@ install {
         developerConnection gitUrl
         url siteUrl
       }
+      
+      // Iterate over the compile dependencies (we don't want the test ones), adding a <dependency> node for each
+      def deps = configurations.compile.allDependencies + configurations.implementation.allDependencies
+      deps.each {
+        dependencies.add("compile", it)
+      }
+
     }
   }
 }


### PR DESCRIPTION
Without this patch.
Java module, correct deps: https://dl.bintray.com/miha-x64/maven/net/aquadc/properties/properties/0.0.3/properties-0.0.3.pom
Android module, no deps: https://dl.bintray.com/miha-x64/maven/net/aquadc/properties/android-bindings/0.0.3/android-bindings-0.0.3.pom

With this patch.
Java module, nothing changed: https://dl.bintray.com/miha-x64/maven/net/aquadc/properties/properties/0.0.4/properties-0.0.4.pom
Android module, dependencies are correct: https://dl.bintray.com/miha-x64/maven/net/aquadc/properties/android-bindings/0.0.4/android-bindings-0.0.4.pom